### PR TITLE
build: remove prerelease arg for releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
           go-version: 1.21
       - uses: go-semantic-release/action@v1
         with:
-          prerelease: true
           hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There's no point in prereleases for something that no one uses.